### PR TITLE
Configurable bot name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ build-iPhoneSimulator/
 .rvmrc
 
 scripts/*.*
+config/environments.local.yml
+config/bot.local.yml

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ run
 
 And set breakpoints and debug.
 
+### configuration
+
+You will need a bot configuration from Slack.  See: https://api.slack.com/bot-users
+
+Once you have configured a bot then you will have a token like: "xoxb-XXXXXXXXXXXX-TTTTTTTTTTTTTT"
+
+You will need to put this in the file config/bot.yml or config/environments.yml for example:
+
+    SLACK_API_TOKEN: 'xoxb-XXXXXXXXXXXX-TTTTTTTTTTTTTT'
+
 ### Running the server
 
 To run sinatra locally simply run:

--- a/config/bot.yml
+++ b/config/bot.yml
@@ -1,0 +1,2 @@
+SLACK_API_TOKEN: 'change me'
+bot_name: 'bot'

--- a/config/environments.yml
+++ b/config/environments.yml
@@ -1,19 +1,16 @@
 development:
-  SLACK_API_TOKEN: "xoxb-77267071536-eoLGgtTgxAY2kcSUrYv9HEK9"
   api_version: '1.0'
   base_path: 'http://localhost:4567'
   swagger_version: '1.1'
   format_specifier: '.json'
   using: 'development'
 test:
-  SLACK_API_TOKEN: "xoxb-77267071536-eoLGgtTgxAY2kcSUrYv9HEK9"
   api_version: '1.0'
   base_path: 'http://localhost:4567'
   swagger_version: '1.1'
   format_specifier: '.json'
   using: 'test'
 production:
-  SLACK_API_TOKEN: "xoxb-77267071536-eoLGgtTgxAY2kcSUrYv9HEK9"
   api_version: '1.0'
   base_path: 'http://localhost:4567'
   swagger_version: '1.1'

--- a/lib/core/realtime.rb
+++ b/lib/core/realtime.rb
@@ -41,15 +41,21 @@ class RealTimeClient
     @client.on :message do |data|
       puts data
       case data.text
-      when 'bot hi' then
-        @client.web_client.chat_postMessage channel: data.channel,
-                                            text: "Hi <@#{data.user}>!"
+      when /#{@bot_name} ping| @#{@bot_name} ping/ then
+          @client.web_client.chat_postMessage channel: data.channel,
+                                              text: 'PONG'
       # Reads from configuration for bot name
       # TODO: get bot name from Slack
       when /#{@bot_name} | @#{@bot_name} / then
         output = @plugins.exec data
-        @client.web_client.chat_postMessage channel: data.channel,
-                                            text: output
+        if output && !output.empty?
+          @client.web_client.chat_postMessage channel: data.channel,
+                                              text: output
+        # TODO: could simply not respond at all or make configurable.
+        else
+          @client.web_client.chat_postMessage channel: data.channel,
+                                              text: "Hi <@#{data.user}>, I did not understand that command."
+        end
       end
     end
 

--- a/lib/core/realtime.rb
+++ b/lib/core/realtime.rb
@@ -41,12 +41,11 @@ class RealTimeClient
     @client.on :message do |data|
       puts data
       case data.text
-      when /#{@bot_name} ping| @#{@bot_name} ping/ then
+      when /^#{@bot_name} ping|^@#{@bot_name} ping|^\<@#{@client.self.id}\> ping/ then
           @client.web_client.chat_postMessage channel: data.channel,
                                               text: 'PONG'
-      # Reads from configuration for bot name
-      # TODO: get bot name from Slack
-      when /#{@bot_name} | @#{@bot_name} / then
+      # Reads from configuration for bot name or uses the bot name/id from Slack
+      when /^#{@bot_name} |^@#{@bot_name} |^\<@#{@client.self.id}\> / then
         output = @plugins.exec data
         if output && !output.empty?
           @client.web_client.chat_postMessage channel: data.channel,
@@ -55,7 +54,7 @@ class RealTimeClient
         else
           @client.web_client.chat_postMessage channel: data.channel,
                                               text: "Hi <@#{data.user}>, I did not understand that command."
-        end
+        end        
       end
     end
 

--- a/lib/core/realtime.rb
+++ b/lib/core/realtime.rb
@@ -21,6 +21,7 @@ class RealTimeClient
     # TODO: Authorization test does not work for realtime client
     # @client.auth_test
     @plugins = Plugins.new
+    @bot_name = settings.bot_name
   end
 
   # Reload all of the plugins from configuration files
@@ -43,11 +44,9 @@ class RealTimeClient
       when 'bot hi' then
         @client.web_client.chat_postMessage channel: data.channel,
                                             text: "Hi <@#{data.user}>!"
-      # it is here that I believe we should parse the second word as the name of the plugin.
-      # Then forward on the request to the plugin based on configuration.
-      # May need a check for configuration of and
-      when /^bot/ then
-
+      # Reads from configuration for bot name
+      # TODO: get bot name from Slack
+      when /#{@bot_name} | @#{@bot_name} / then
         output = @plugins.exec data
         @client.web_client.chat_postMessage channel: data.channel,
                                             text: output

--- a/slapi.rb
+++ b/slapi.rb
@@ -12,6 +12,7 @@ class Slapi < Sinatra::Application
   # enable :sessions
 
   config_file 'config/environments.yml'
+  config_file 'config/bot.yml'
 
   configure :production, :development, :test do
     enable :logging


### PR DESCRIPTION
Allow the bot name to be configurable in the settings instead of hard coded as "bot".

Would be better to read from Slack the name of the bot, but this will give separation for testing for the time being.
